### PR TITLE
Add body scroll lock composable and integrate with ModalBs

### DIFF
--- a/resources/js/Components/ModalBs.vue
+++ b/resources/js/Components/ModalBs.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { computed } from "vue";
-import { ref } from "vue";
+import { useBodyScrollLock } from "@/Composables/useBodyScrollLock";
+import { computed, watch } from "vue";
 
 const props = defineProps({
   title: {
@@ -34,16 +34,15 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  // toggleModalClose: {
-  //     type: Function,
-  //     require: true,
-  // }
 });
+const isOpen = computed(() => props.ModalStatus);
+const { lock, unlock } = useBodyScrollLock(isOpen);
+watch(isOpen, (v) => (v ? lock() : unlock()), { immediate: true });
 </script>
 <template>
   <div
     v-if="ModalStatus"
-    class="modalbs fixed inset-0 z-[1300] bg-black bg-opacity-50 flex justify-center transition-opacity"
+    class="modalbs fixed inset-0 z-[1300] bg-black bg-opacity-50 flex justify-center transition-opacity overflow-y-scroll"
     :class="modalPosition"
     tabindex="-1"
   >

--- a/resources/js/Components/Navbar.vue
+++ b/resources/js/Components/Navbar.vue
@@ -11,7 +11,7 @@
     </div>
 
     <!-- Right navbar links -->
-    <div class="relative" :class="props.isSidebarVisible ? 'mr-[16%]' : 'mr-0'">
+    <div class="relative" :class="props.isSidebarVisible ? 'mr-[300px]' : 'mr-0'">
       <!-- <button class="nav-item dropdown"> -->
       <div class="nav-link cursor-pointer" @click="toggleDropdown">
         {{ page.props.auth.user.name }}

--- a/resources/js/Composables/useBodyScrollLock.ts
+++ b/resources/js/Composables/useBodyScrollLock.ts
@@ -1,0 +1,50 @@
+// useBodyScrollLock.ts (Vue 3 composable)
+import { onMounted, onBeforeUnmount } from 'vue';
+
+export function useBodyScrollLock(activeRef: { value: boolean }) {
+  let scrollY = 0;
+
+  const lock = () => {
+    // sudah di-lock? skip
+    if (document.body.style.position === 'fixed') return;
+
+    // simpan posisi scroll sekarang
+    scrollY = window.scrollY || window.pageYOffset;
+
+    // hitung lebar scrollbar untuk hindari layout shift
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+    }
+
+    // kunci body
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.left = '0';
+    document.body.style.right = '0';
+    document.body.style.width = '100%'; // cegah “ngelebar”
+    document.body.style.overflow = 'hidden'; // jaga-jaga
+  };
+
+  const unlock = () => {
+    if (document.body.style.position !== 'fixed') return;
+
+    // lepas kunci
+    document.body.style.position = '';
+    document.body.style.top = '';
+    document.body.style.left = '';
+    document.body.style.right = '';
+    document.body.style.width = '';
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
+
+    // kembalikan posisi scroll semula
+    window.scrollTo(0, scrollY);
+  };
+
+  // opsional: auto apply saat mount/unmount jika activeRef sudah true
+  onMounted(() => { if (activeRef.value) lock(); });
+  onBeforeUnmount(() => { if (activeRef.value) unlock(); });
+
+  return { lock, unlock };
+}


### PR DESCRIPTION
Introduced a new useBodyScrollLock composable to lock body scroll when a modal is open. Updated ModalBs.vue to use this composable, ensuring the background does not scroll when the modal is active. Also adjusted Navbar.vue sidebar margin from 16% to 300px for improved layout consistency.